### PR TITLE
Add mongo test hooks

### DIFF
--- a/airbyte-integrations/connectors/source-mongodb/build.gradle
+++ b/airbyte-integrations/connectors/source-mongodb/build.gradle
@@ -6,21 +6,22 @@ plugins {
 }
 
 airbyteStandardSourceTestFile {
-    def dbName = "mongo-test-${System.currentTimeMillis()}"
+    def dbName = "mongo-airbyte-integration-test"
     prehook {
         project.exec {
-            def args = ["docker", "run",
-                        "--rm",
-                        "-v", "${project.path}/bin:/docker-entrypoint-initdb.d",
+            def args = ["docker", "run", "--rm",
                         "--name", dbName,
-                        "mongo:4.0.23"]
+                        "airbyte/mongodb-integration-test-seed"]
+            commandLine args
         }
-        println('HOOOOOHOHOHOHOHOHOOHello')
-        logger.error("HOOOOOHOHOHOHOHOHOOHello")
+
+        
     }
 
     posthook {
-        logger.error("HOOOOOHOHOHOHOHOHOOHello BYEYBYEYBYE")
+        project.exec {
+            commandLine ["docker", "stop", dbName]
+        }
     }
 
     // All these input paths must live inside this connector's directory (or subdirectories)

--- a/airbyte-integrations/connectors/source-mongodb/build.gradle
+++ b/airbyte-integrations/connectors/source-mongodb/build.gradle
@@ -11,7 +11,7 @@ airbyteStandardSourceTestFile {
         project.exec {
             def args = ["docker", "run", "--rm",
                         "--name", dbName,
-                        "airbyte/mongodb-integration-test-seed"]
+                        "airbyte/mongodb-integration-test-seed:dev"]
             commandLine args
         }
 

--- a/airbyte-integrations/connectors/source-mongodb/build.gradle
+++ b/airbyte-integrations/connectors/source-mongodb/build.gradle
@@ -11,6 +11,11 @@ airbyteStandardSourceTestFile {
         project.exec {
             def args = ["docker", "run", "--rm",
                         "--name", dbName,
+                        "-d",
+                        // assign to a weird port number so we don't conflict with any locally running mongo instances
+                        "-p", "27888:27017",
+                        "-e", "MONGO_INITDB_ROOT_USERNAME=user",
+                        "-e", "MONGO_INITDB_ROOT_PASSWORD=password",
                         "airbyte/mongodb-integration-test-seed:dev"]
             commandLine args
         }
@@ -25,7 +30,7 @@ airbyteStandardSourceTestFile {
     }
 
     // All these input paths must live inside this connector's directory (or subdirectories)
-    configPath = "secrets/valid_config.json"
+    configPath = "secrets.sample/valid_config.json"
     configuredCatalogPath = "secrets/fullrefresh_configured_catalog.json"
     specPath = "lib/spec.json"
 }

--- a/airbyte-integrations/connectors/source-mongodb/build.gradle
+++ b/airbyte-integrations/connectors/source-mongodb/build.gradle
@@ -6,6 +6,23 @@ plugins {
 }
 
 airbyteStandardSourceTestFile {
+    def dbName = "mongo-test-${System.currentTimeMillis()}"
+    prehook {
+        project.exec {
+            def args = ["docker", "run",
+                        "--rm",
+                        "-v", "${project.path}/bin:/docker-entrypoint-initdb.d",
+                        "--name", dbName,
+                        "mongo:4.0.23"]
+        }
+        println('HOOOOOHOHOHOHOHOHOOHello')
+        logger.error("HOOOOOHOHOHOHOHOHOOHello")
+    }
+
+    posthook {
+        logger.error("HOOOOOHOHOHOHOHOHOOHello BYEYBYEYBYE")
+    }
+
     // All these input paths must live inside this connector's directory (or subdirectories)
     configPath = "secrets/valid_config.json"
     configuredCatalogPath = "secrets/fullrefresh_configured_catalog.json"

--- a/airbyte-integrations/connectors/source-mongodb/secrets.sample/valid_config.json
+++ b/airbyte-integrations/connectors/source-mongodb/secrets.sample/valid_config.json
@@ -1,8 +1,8 @@
 {
   "host": "127.0.0.1",
-  "port": "27017",
+  "port": "27888",
   "database": "sample_analytics",
-  "user": "USER",
-  "password": "PASSWORD",
+  "user": "user",
+  "password": "password",
   "auth_source": "admin"
 }

--- a/buildSrc/src/main/groovy/airbyte-standard-source-test-file.gradle
+++ b/buildSrc/src/main/groovy/airbyte-standard-source-test-file.gradle
@@ -68,6 +68,9 @@ class AirbyteStandardSourceTestFilePlugin implements Plugin<Project> {
         project.standardSourceTestFile.dependsOn(':airbyte-integrations:bases:base-standard-source-test-file:airbyteDocker')
         project.standardSourceTestFile.dependsOn(project.build)
         project.standardSourceTestFile.dependsOn(project.airbyteDocker)
+        if (project.hasProperty('airbyteDockerTest')){
+            project.standardSourceTestFile.dependsOn(project.airbyteDockerTest)
+        }
 
         // make sure we create the integrationTest task once in case a java integration test was already initialized
         if (!project.hasProperty('integrationTest')) {

--- a/buildSrc/src/main/groovy/airbyte-standard-source-test-file.gradle
+++ b/buildSrc/src/main/groovy/airbyte-standard-source-test-file.gradle
@@ -2,6 +2,8 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 
 abstract class AirbyteStandardSourceTestFileConfiguration {
+    Closure prehook
+    Closure posthook
     String configPath
     String configuredCatalogPath
     String specPath
@@ -26,32 +28,37 @@ class AirbyteStandardSourceTestFilePlugin implements Plugin<Project> {
 
         project.task('standardSourceTestFile') {
             doFirst {
-                project.exec {
-                    validateConfig(config)
-                    def targetMountDirectory = "/test_input"
-                    def args = [
-                            'docker', 'run', '--rm', '-i',
-                            // provide access to the docker daemon
-                            '-v', "/var/run/docker.sock:/var/run/docker.sock",
-                            // A container within a container mounts from the host filesystem, not the parent container.
-                            // this forces /tmp to be the same directory for host, parent container, and child container.
-                            '-v', "/tmp:/tmp",
-                            // mount the project dir. all provided input paths must be relative to that dir.
-                            '-v', "${project.projectDir.absolutePath}:${targetMountDirectory}",
-                            '--name', "std-fs-source-test-${project.name}",
-                            'airbyte/base-standard-source-test-file:dev',
-                            '--imageName', DockerHelpers.getDevTaggedImage(project.projectDir, 'Dockerfile'),
-                            '--catalog', "${targetMountDirectory}/${config.configuredCatalogPath}",
-                            '--spec', "${targetMountDirectory}/${config.specPath}",
-                            '--config', "${targetMountDirectory}/${config.configPath}",
-                    ]
+                config.prehook.call()
+                try {
+                    project.exec {
+                        validateConfig(config)
+                        def targetMountDirectory = "/test_input"
+                        def args = [
+                                'docker', 'run', '--rm', '-i',
+                                // provide access to the docker daemon
+                                '-v', "/var/run/docker.sock:/var/run/docker.sock",
+                                // A container within a container mounts from the host filesystem, not the parent container.
+                                // this forces /tmp to be the same directory for host, parent container, and child container.
+                                '-v', "/tmp:/tmp",
+                                // mount the project dir. all provided input paths must be relative to that dir.
+                                '-v', "${project.projectDir.absolutePath}:${targetMountDirectory}",
+                                '--name', "std-fs-source-test-${project.name}",
+                                'airbyte/base-standard-source-test-file:dev',
+                                '--imageName', DockerHelpers.getDevTaggedImage(project.projectDir, 'Dockerfile'),
+                                '--catalog', "${targetMountDirectory}/${config.configuredCatalogPath}",
+                                '--spec', "${targetMountDirectory}/${config.specPath}",
+                                '--config', "${targetMountDirectory}/${config.configPath}",
+                        ]
 
-                    if (config.statePath != null){
-                        args.add("--state")
-                        args.add("${targetMountDirectory}/${config.statePath}")
+                        if (config.statePath != null) {
+                            args.add("--state")
+                            args.add("${targetMountDirectory}/${config.statePath}")
+                        }
+
+                        commandLine args
                     }
-
-                    commandLine args
+                } finally {
+                    config.posthook.call()
                 }
             }
 


### PR DESCRIPTION
## What
Adds pre/post hooks to instantiate and tear down the mongo db docker container used in standard testing. 

To run integration tests run ` ./gradlew :airbyte-integrations:connectors:source-mongodb:integrationTest`